### PR TITLE
Added Dynamic Include

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,12 @@
+DEP_DIR := deps
+
+# Find all /deps foldrers and build a dynamic -I flag for each.
+INCLUDES := $(wildcard $(DEP_DIR)/**)
+INCLUDES := $(foreach dir,$(INCLUDES), -I$(dir))
+
+
 test:
-	gcc test.c -o test
+	gcc $(INCLUDES) test.c -o test
 
 clean:
 	rm -rf ./test

--- a/butterknife.h
+++ b/butterknife.h
@@ -6,12 +6,11 @@
 #ifndef BUTTERKNIFE_H
 #define BUTTERKNIFE_H
 
-#include "deps/tiny-regex-c/re.h"
-#include "deps/buffer/buffer.h"
-#include "deps/fs/fs.h"
-#include "deps/vec/vec.h"
-
 #include <unistd.h>
+#include <re.h>
+#include <buffer.h>
+#include <fs.h>
+#include <vec.h>
 
 #ifndef FS_PATH_MAX
 #define FS_PATH_MAX 1024


### PR DESCRIPTION
Setup Dynamic Includes in order to clibs files to be added without changing the makefile.

Fixes #9 